### PR TITLE
Improve Output Parsing, Add Debug Mode, and Handle Edge Cases

### DIFF
--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -115,6 +115,19 @@ mock_ccusage_not_installed() {
     :
 }
 
+# Mock ccusage with alternative format (e.g., time format variations)
+mock_ccusage_alternative_format() {
+    mock_command "ccusage" "cat <<'CCUSAGE_EOF'
+Active block
+3h 15m remaining
+CCUSAGE_EOF"
+}
+
+# Mock ccusage with empty output
+mock_ccusage_empty_output() {
+    mock_command "ccusage" "echo ''; exit 0"
+}
+
 # Create a fake activity file with specific timestamp
 create_activity_file() {
     local age_seconds="$1"


### PR DESCRIPTION
Changes:
- Add whitespace trimming and carriage return handling for robust parsing
- Expand success patterns to recognize more output format variations:
  * "Active block" (without "Block N (Current)" prefix)
  * Time formats like "3h 15m" (with or without "remaining")
  * All case-insensitive matching
- Add explicit empty output detection with specific warning message
- Add debug logging when CCBLOCKS_DEBUG=1 to show actual ccusage output
- Log unrecognized output to system logger for troubleshooting
- Add test coverage for alternative formats and edge cases

The verification remains optional and non-fatal, but now provides better diagnostics for troubleshooting platform-specific output format differences.

Users experiencing warnings can set `CCBLOCKS_DEBUG=1` to see the actual ccusage output format and report it for further pattern additions.

Fixes #2