### PR TITLE
fix: add [Install] section so timer autostarts on boot

### DIFF
--- a/libexec/lib/systemd-helper.sh
+++ b/libexec/lib/systemd-helper.sh
@@ -77,6 +77,9 @@ Description=ccblocks Scheduling Timer (%i)
 [Timer]
 OnCalendar=$oncalendar
 Persistent=true
+
+[Install]
+WantedBy=timers.target
 EOF
 
 	print_status "Created systemd service and timer files"
@@ -116,6 +119,9 @@ Description=ccblocks Scheduling Timer (%i)
 [Timer]
 OnCalendar=$oncalendar
 Persistent=true
+
+[Install]
+WantedBy=timers.target
 EOF
 
 	print_status "Created custom systemd service and timer files"


### PR DESCRIPTION
## Problem

The systemd timer template generated by `systemd-helper.sh` has no `[Install]` section. As a result, `systemctl --user enable ccblocks@default.timer` cannot create the `timers.target.wants` symlink — the unit stays `static`:

```
$ systemctl --user is-enabled ccblocks@default.timer
static
```

The timer appears to work only because `enable_timer` also runs `systemctl --user start`, which keeps it active for the current session. After a reboot the timer is **not** pulled in by `timers.target`, so ccblocks does not autostart.

## Fix

Add an `[Install]` section with `WantedBy=timers.target` to both timer templates (the `247`/`work`/`night` presets in `create_service` and the custom-hours path in `create_service_custom`). With this, `systemctl --user enable` correctly links the timer for boot:

```
$ systemctl --user is-enabled ccblocks@default.timer
enabled
```

## Note on lingering

For the timer to fire at boot *without* an interactive login, users also need lingering enabled:

```
sudo loginctl enable-linger "$USER"
```

This is a system-level action requiring sudo, so it's out of scope for this change, but it may be worth documenting in the README as part of the install instructions.